### PR TITLE
fix(grafana): align kupo-dolos dashboard and alerts with live metrics

### DIFF
--- a/grafana/alerts/demeter/kupo.json
+++ b/grafana/alerts/demeter/kupo.json
@@ -558,7 +558,7 @@
                                     "uid": "${datasource_uid_map.gke_blinklabs-demeter_us-central1_dmtr-cluster-prometheus}"
                                 },
                                 "editorMode": "code",
-                                "expr": "max(dolos_tip_slot) by (pod) - max(kupo_most_recent_point_slot_no) by (pod)",
+                                "expr": "clamp_min(max(dolos_slot) by (pod) - max(kupo_most_recent_checkpoint) by (pod), 0)",
                                 "instant": false,
                                 "intervalMs": 1000,
                                 "legendFormat": "__auto",

--- a/grafana/dashboards/shared/kupo-dolos.json
+++ b/grafana/dashboards/shared/kupo-dolos.json
@@ -174,7 +174,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(kupo_most_recent_point_slot_no{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(kupo_most_recent_checkpoint{pod=~\".*$network.*\"}) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -236,7 +236,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(dolos_tip_slot{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(dolos_slot{pod=~\".*$network.*\"}) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -306,7 +306,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(dolos_tip_slot{pod=~\".*$network.*\"}) by (pod) - max(kupo_most_recent_point_slot_no{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "clamp_min(max(dolos_slot{pod=~\".*$network.*\"}) by (pod) - max(kupo_most_recent_checkpoint{pod=~\".*$network.*\"}) by (pod), 0)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -385,7 +385,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(dolos_sync_progress{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(dolos_slot{pod=~\".*$network.*\"}) by (pod) / scalar(max(cardano_node_metrics_slotNum_int{network=\"$network\"}))",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -495,7 +495,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(kupo_most_recent_point_slot_no{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(kupo_most_recent_checkpoint{pod=~\".*$network.*\"}) by (pod)",
           "legendFormat": "kupo indexed \u2014 {{pod}}",
           "range": true,
           "refId": "A"
@@ -506,7 +506,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(dolos_tip_slot{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(dolos_slot{pod=~\".*$network.*\"}) by (pod)",
           "legendFormat": "dolos tip \u2014 {{pod}}",
           "range": true,
           "refId": "B"
@@ -613,7 +613,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(dolos_tip_slot{pod=~\".*$network.*\"}) by (pod) - max(kupo_most_recent_point_slot_no{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "clamp_min(max(dolos_slot{pod=~\".*$network.*\"}) by (pod) - max(kupo_most_recent_checkpoint{pod=~\".*$network.*\"}) by (pod), 0)",
           "legendFormat": "lag \u2014 {{pod}}",
           "range": true,
           "refId": "A"
@@ -792,7 +792,7 @@
       "id": 10,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -812,7 +812,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max(kupo_database_size_bytes{pod=~\".*$network.*\"}) by (pod)",
+          "expr": "max(label_replace(kubelet_volume_stats_used_bytes{persistentvolumeclaim=~\"data-dolos-.*$network.*\"}, \"pod\", \"$1\", \"persistentvolumeclaim\", \"data-(.*)\")) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -882,7 +882,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_status_restarts_total{pod=~\".*kupo.*$network.*\", container=\"kupo\"}) by (pod)",
+          "expr": "sum(kube_pod_container_status_restarts_total{pod=~\".*dolos.*$network.*\", container=\"dolos\"}) by (pod) or sum(label_replace(kube_pod_container_status_restarts_total{exported_pod=~\".*dolos.*$network.*\", exported_container=\"dolos\"}, \"pod\", \"$1\", \"exported_pod\", \"(.*)\")) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -1091,7 +1091,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "rate(dolos_chain_sync_events_total{pod=~\".*$network.*\"}[$__rate_interval])",
+          "expr": "rate(dolos_block_number{pod=~\".*$network.*\"}[$__rate_interval])",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -1506,7 +1506,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{pod=~\".*kupo.*$network.*\", container=\"kupo\"})",
+          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{pod=~\".*dolos.*$network.*\", container=\"dolos\"}) or sum by (pod) (label_replace(kube_pod_container_status_restarts_total{exported_pod=~\".*dolos.*$network.*\", exported_container=\"dolos\"}, \"pod\", \"$1\", \"exported_pod\", \"(.*)\"))",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -1623,7 +1623,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (pod, container) (container_memory_working_set_bytes{pod=~\".*kupo.*$network.*\", container!=\"\"}) / sum by (pod, container) (container_spec_memory_limit_bytes{pod=~\".*kupo.*$network.*\", container!=\"\"})",
+          "expr": "sum by (pod, container) (container_memory_working_set_bytes{pod=~\".*dolos.*$network.*\", container!=\"socat-ntc\", container!=\"\"}) / sum by (pod, container) (container_spec_memory_limit_bytes{pod=~\".*dolos.*$network.*\", container!=\"socat-ntc\", container!=\"\"})",
           "legendFormat": "{{container}} \u2014 {{pod}}",
           "range": true,
           "refId": "A"
@@ -1718,7 +1718,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (pod, container) (rate(container_cpu_usage_seconds_total{pod=~\".*kupo.*$network.*\", container!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (pod, container) (rate(container_cpu_usage_seconds_total{pod=~\".*dolos.*$network.*\", container!=\"socat-ntc\", container!=\"\"}[$__rate_interval]))",
           "legendFormat": "{{container}} \u2014 {{pod}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
- Update 'dolos_tip_slot' to 'dolos_slot' to match live Dolos-exposed metrics.
- Update 'kupo_most_recent_point_slot_no' to 'kupo_most_recent_checkpoint' to match live Kupo metrics.
- Clamp indexing lag calculations to 0 using clamp_min to prevent negative values caused by scrape timing jitter.
- Redirect CPU and Memory resource panels to target 'dolos' container inside dolos pods instead of standalone kupo.
- Filter out 'socat-ntc' utility container from resource graphs to prevent division-by-zero (NaN) rendering failures.
- Map 'Database Size' panel to kubelet PVC volume stats and disable its sparkline to prevent trend-line auto-scaling confusion.
- Map 'Dolos Chain Sync Events' rate to 'dolos_block_number' as the old event counter is obsolete.
- Map 'Dolos Sync Progress' to dynamically calculate progress against synced reference cardano-nodes in the cluster.
<img width="964" height="1069" alt="dashboard" src="https://github.com/user-attachments/assets/5c58b741-3085-4f37-a165-0ef9450b1517" />
