### PR TITLE
fix(grafana): correct Dolos memory namespace, repoint UTxO RPC request rate dashboards pannel

### DIFF
--- a/grafana/dashboards/shared/blockfrost.json
+++ b/grafana/dashboards/shared/blockfrost.json
@@ -999,7 +999,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"ftr-dolos-m1\", container!=\"\", pod=~\"cardano-$network-.*\"}) by (pod)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"ext-utxorpc-m1\", container!=\"\", pod=~\"cardano-$network-.*\"}) by (pod)",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,
@@ -1463,10 +1463,7 @@
     "list": [
       {
         "allowCustomValue": true,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "multi": false,

--- a/grafana/dashboards/shared/blockfrost.json
+++ b/grafana/dashboards/shared/blockfrost.json
@@ -999,14 +999,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"ext-utxorpc-m1\", container!=\"\", pod=~\"cardano-$network-.*\"}) by (pod)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=~\"dolos|ext-blockfrost-m1\", container!=\"\", pod=~\"dolos-blockfrost-proxy-.*|proxy-.*\"}) by (pod)",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Dolos Memory Usage",
+      "title": "Blockfrost Proxy Memory Usage",
       "type": "timeseries"
     },
     {
@@ -1490,9 +1490,14 @@
             "selected": true,
             "text": "ext-blockfrost-m1",
             "value": "ext-blockfrost-m1"
+          },
+          {
+            "selected": false,
+            "text": "dolos",
+            "value": "dolos"
           }
         ],
-        "query": "ext-blockfrost-m1",
+        "query": "ext-blockfrost-m1,dolos",
         "skipUrlSync": false,
         "type": "custom",
         "valuesFormat": "csv"

--- a/grafana/dashboards/shared/utxorpc.json
+++ b/grafana/dashboards/shared/utxorpc.json
@@ -123,7 +123,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(pod, container)(container_memory_working_set_bytes{namespace=~\"dolos|ext-utxorpc-m1\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}) / sum by (pod, container)(container_spec_memory_limit_bytes{namespace=~\"dolos|ext-utxorpc-m1\",pod=~\"dolos-$network-az.*|cardano-$network-.*\",container!=\"\"})\n",
+          "expr": "sum by(pod, container)(container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}) / sum by (pod, container)(container_spec_memory_limit_bytes{namespace=~\"$namespace\",pod=~\"dolos-$network-az.*|cardano-$network-.*\",container!=\"\"})\n",
           "legendFormat": "{{ container }} - {{ pod }}",
           "range": true,
           "refId": "A"
@@ -228,7 +228,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(pod, container)(rate(container_cpu_usage_seconds_total{namespace=~\"dolos|ext-utxorpc-m1\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}[$__rate_interval]))",
+          "expr": "sum by(pod, container)(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -311,7 +311,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"dolos|ext-utxorpc-m1\" } / on(persistentvolumeclaim) kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"dolos|ext-utxorpc-m1\"}",
+          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"$namespace\" } / on(persistentvolumeclaim) kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"$namespace\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -539,6 +539,33 @@
         "query": "prometheus",
         "refresh": 1,
         "type": "datasource"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "dolos",
+          "value": "dolos"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "dolos",
+            "value": "dolos"
+          },
+          {
+            "selected": false,
+            "text": "ext-utxorpc-m1",
+            "value": "ext-utxorpc-m1"
+          }
+        ],
+        "query": "dolos,ext-utxorpc-m1",
+        "skipUrlSync": false,
+        "type": "custom",
+        "valuesFormat": "csv"
       },
       {
         "current": {

--- a/grafana/dashboards/shared/utxorpc.json
+++ b/grafana/dashboards/shared/utxorpc.json
@@ -123,7 +123,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(pod, container)(container_memory_working_set_bytes{namespace=\"ext-utxorpc-m1\", pod=~\"cardano-$network-.*\", container!=\"\"}) / sum by (pod, container)(container_spec_memory_limit_bytes{namespace=\"ext-utxorpc-m1\",pod=~\"cardano-$network-.*\",container!=\"\"})\n",
+          "expr": "sum by(pod, container)(container_memory_working_set_bytes{namespace=~\"dolos|ext-utxorpc-m1\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}) / sum by (pod, container)(container_spec_memory_limit_bytes{namespace=~\"dolos|ext-utxorpc-m1\",pod=~\"dolos-$network-az.*|cardano-$network-.*\",container!=\"\"})\n",
           "legendFormat": "{{ container }} - {{ pod }}",
           "range": true,
           "refId": "A"
@@ -228,7 +228,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by(pod, container)(rate(container_cpu_usage_seconds_total{namespace=\"ext-utxorpc-m1\", pod=~\"cardano-$network-.*\", container!=\"\"}[$__rate_interval]))",
+          "expr": "sum by(pod, container)(rate(container_cpu_usage_seconds_total{namespace=~\"dolos|ext-utxorpc-m1\", pod=~\"dolos-$network-az.*|cardano-$network-.*\", container!=\"\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -311,7 +311,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"pvc-.*\", exported_namespace=\"ext-utxorpc-m1\" } / on(persistentvolumeclaim) kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"pvc-.*\", exported_namespace=\"ext-utxorpc-m1\"}",
+          "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"dolos|ext-utxorpc-m1\" } / on(persistentvolumeclaim) kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"pvc-.*|data-dolos-.*\", exported_namespace=~\"dolos|ext-utxorpc-m1\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/grafana/dashboards/shared/utxorpc.json
+++ b/grafana/dashboards/shared/utxorpc.json
@@ -413,7 +413,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "\nsum(rate( grpc_server_handled_total{grpc_service=~\"utxorpc.*\"} [$__rate_interval])) by (grpc_method)\n",
+          "expr": "sum(rate( utxorpc_proxy_total_requests{network=~\".*$network.*\"} [$__rate_interval])) by (status_code)",
           "interval": "",
           "key": "Q-ad132e3e-b05b-405d-b2e8-e791bff8b3cc-0",
           "legendFormat": "__auto",
@@ -532,6 +532,7 @@
   "templating": {
     "list": [
       {
+        "current": {},
         "includeAll": false,
         "name": "datasource",
         "options": [],


### PR DESCRIPTION
Closes: #57

## What this does

Fixes the Blockfrost and UTxO RPC dashboards so they actually render on both Demeter backends. The old queries were hardcoded to TxPipe-only namespaces/pod names, so on our BlinkLabs cluster these panels were just showing "No data".

The root cause: the two providers name things differently.

- **BlinkLabs (GKE):** everything dolos-related lives in the `dolos` namespace — the proxy is `dolos-blockfrost-proxy-*`, the U5C nodes are `dolos-<network>-az*-0`, and their PVCs are `data-dolos-<network>-az*-*`.
- **TxPipe (AWS):** proxy in `ext-blockfrost-m1` as `proxy-*`, U5C nodes in `ext-utxorpc-m1` as `cardano-<network>-*`, PVCs `pvc-*`.

There is no `ext-utxorpc-m1` namespace on BlinkLabs at all, which is why the original memory panel was blank.

## Changes

**`blockfrost.json`**
- Repointed the memory panel to match the proxy on both providers: `namespace=~"dolos|ext-blockfrost-m1"`, `pod=~"dolos-blockfrost-proxy-.*|proxy-.*"`.
- Renamed the panel `Dolos Memory Usage` → `Blockfrost Proxy Memory Usage`, since it's really measuring the proxy pods, not the dolos node.
- Added `dolos` to the `namespace` template variable so it's selectable when the BlinkLabs datasource is picked.

**`utxorpc.json`**
- Repointed the request-rate panel to the proxy metric so it reflects real traffic.
- Updated the three node panels (Memory / CPU / Disk) to support both providers with an alternation rather than a single hardcoded namespace:
  - namespace `dolos|ext-utxorpc-m1`
  - pods `dolos-$network-az.*|cardano-$network-.*`
  - PVCs `pvc-.*|data-dolos-.*`

## How I verified

Checked the real pod/PVC names on the BlinkLabs cluster (`kubectl get pods/pvc -n dolos`) and confirmed the fully-anchored PromQL patterns match the intended pods on BlinkLabs without catching anything else, while keeping the existing TxPipe patterns intact in the alternation. Both dashboard JSON files pass validation.


