### PR TITLE
feat(cloudflare): cover ogmios v7 hostnames with a certificate pack

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -139,6 +139,33 @@ resource "cloudflare_certificate_pack" "this" {
   validity_days     = 90
 }
 
+# Ogmios v7 hostnames, issued by fabric as
+# {key}.cardano-{network}-v7.ogmios-m1.dmtr.host.
+#
+# A separate pack rather than three more entries above, because the Cloudflare
+# API only orders and deletes certificate packs — it cannot update the host
+# list of one. Editing hosts on the pack above therefore destroys the live
+# certificate and orders a replacement, and that certificate is what serves
+# every customer hostname for Ogmios v6, Kupo, Blockfrost and UTxO RPC. This
+# way the worst case is a rejected order rather than an uncovered zone.
+#
+# The unauthenticated endpoint cardano-{network}-v7.ogmios-m1.dmtr.host needs
+# no entry: *.ogmios-m1.dmtr.host above already covers it.
+resource "cloudflare_certificate_pack" "ogmios_v7" {
+  zone_id               = cloudflare_zone.this[var.cloudflare_zone_name].id
+  certificate_authority = "google"
+
+  // At most 50.
+  hosts = [
+    "*.cardano-mainnet-v7.ogmios-m1.dmtr.host",
+    "*.cardano-preprod-v7.ogmios-m1.dmtr.host",
+    "*.cardano-preview-v7.ogmios-m1.dmtr.host",
+  ]
+  type              = "advanced"
+  validation_method = "txt"
+  validity_days     = 90
+}
+
 # Kupo
 resource "cloudflare_load_balancer_monitor" "kupo_m1_monitor" {
   account_id  = var.cloudflare_account_id


### PR DESCRIPTION
## What this fixes

Ogmios v7 is being rolled out to the Console for cardano mainnet, preprod and preview (demeter-run/fabric#273). Fabric issues `{key}.cardano-{network}-v7.ogmios-m1.dmtr.host` — and **the edge has no certificate for that name today**:

```
$ openssl s_client -servername test.cardano-preprod-v7.ogmios-m1.dmtr.host \
    -connect test.cardano-preprod-v7.ogmios-m1.dmtr.host:443
  ...ssl/tls alert handshake failure (SSL alert number 40)

$ openssl s_client -servername test.cardano-preprod-v6.ogmios-m1.dmtr.host ...
  subject=CN=*.dmtr.host   issuer=Google Trust Services
  DNS:*.cardano-preprod-v6.ogmios-m1.dmtr.host   # ...and the rest of this pack
```

DNS and routing already work — the wildcard covers the subtree and `*.ogmios-m1.dmtr.host` splat load balancer fronts every network and version, so **no record, pool, monitor or load balancer change is needed**. Certificate coverage is the only gap.

## Why a second pack instead of three more hosts on `cloudflare_certificate_pack.this`

The Cloudflare API orders and deletes certificate packs; it has no update for a pack's host list. Editing `hosts` on the existing resource is therefore a **destroy-and-replace** of the certificate that currently serves every customer hostname for Ogmios v6, Kupo, Blockfrost and UTxO RPC — uncovered from the destroy until the replacement is issued.

Ordering a separate pack is additive and never touches that certificate. If the zone will not take a second advanced pack, the apply fails and nothing has changed. (The zone demonstrably serves more than one multi-SAN certificate already — the short-form legacy hostnames like `*.preprod-v6.ogmios-m1.dmtr.host` are on a different, unmanaged certificate.)

Consolidating the two packs is worth doing at a quiet moment, with the same replacement caveat; it is deliberately not bundled with a rollout step.

## Scope notes

- Three hosts. The unauthenticated endpoint `cardano-{network}-v7.ogmios-m1.dmtr.host` needs no entry — `*.ogmios-m1.dmtr.host` on the existing pack covers it.
- No `-v7` entries for vector/prime testnet: v7 is not offered on those networks.
- Host budget: the existing pack stays at 26 of its 50; this one uses 3 of its own.

## How to apply (targeted — do not run a bare apply)

```
gh workflow run run-terraform.yml --repo demeter-run/global \
  -f arguments="plan -target=cloudflare_certificate_pack.ogmios_v7"
```

Expect **1 to add, 0 to change, 0 to destroy**. If the plan proposes destroying `cloudflare_certificate_pack.this`, stop — the target was dropped. Then the same with `apply -auto-approve -target=...`.

## Verification

- `terraform fmt -check` and `terraform validate`: pass.
- Not applied. Post-apply gate: the handshake above succeeds and `curl` returns 401 (proxy reached) rather than an SSL alert, on all three networks, with v6 unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)