### PR TITLE
feat(cloudflare): cover ogmios v7 hostnames

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -101,6 +101,9 @@ resource "cloudflare_certificate_pack" "this" {
     "*.vector-mainnet-v6.ogmios-m1.dmtr.host",
     "*.vector-testnet-v6.ogmios-m1.dmtr.host",
     "*.prime-testnet-v6.ogmios-m1.dmtr.host",
+    "*.cardano-mainnet-v7.ogmios-m1.dmtr.host",
+    "*.cardano-preprod-v7.ogmios-m1.dmtr.host",
+    "*.cardano-preview-v7.ogmios-m1.dmtr.host",
 
     // Kupo
     "*.kupo-m1.dmtr.host",


### PR DESCRIPTION
## What this fixes

Ogmios v7 is being offered in the Console for cardano mainnet, preprod and preview (demeter-run/fabric#273). Fabric issues `{key}.cardano-{network}-v7.ogmios-m1.dmtr.host`, and the edge has no certificate for that name:

```
$ openssl s_client -servername test.cardano-preprod-v7.ogmios-m1.dmtr.host \
    -connect test.cardano-preprod-v7.ogmios-m1.dmtr.host:443
  ...ssl/tls alert handshake failure (SSL alert number 40)

$ openssl s_client -servername test.cardano-preprod-v6.ogmios-m1.dmtr.host ...
  subject=CN=*.dmtr.host   issuer=Google Trust Services
  DNS:*.cardano-preprod-v6.ogmios-m1.dmtr.host   # ...and the rest of this pack
```

Routing already works: the DNS wildcard covers the subtree and `*.ogmios-m1.dmtr.host` fronts every network and version, so **no record, pool, monitor or load balancer change is needed.** Certificate coverage is the only gap.

## Scope

Three hosts, added to the Ogmios group of the existing pack:

- The 3-label unauthenticated endpoint `cardano-{network}-v7.ogmios-m1.dmtr.host` needs no entry — `*.ogmios-m1.dmtr.host` covers it.
- No v7 for vector/prime testnet: not offered on those networks.
- `*.dmtr.host` stays first in the list, so the certificate's CN is unchanged.
- Host count goes 26 → **29 of the 50 maximum**.

## How to apply

```
gh workflow run run-terraform.yml --repo demeter-run/global \
  -f arguments="plan -target=cloudflare_certificate_pack.this"
```

Read the plan before applying — it will say whether the provider updates the pack in place or replaces it, and nothing else should be touched. Then the same with `apply -auto-approve -target=cloudflare_certificate_pack.this`.

## Verification

- `terraform fmt -check` and `terraform validate`: pass.
- Not applied. Post-apply gate: the handshake above succeeds and `curl` returns 401 (proxy reached, no key) on all three v7 networks, and a v6 hostname still returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)